### PR TITLE
support vllm & lightllm

### DIFF
--- a/longeval/eval.py
+++ b/longeval/eval.py
@@ -63,6 +63,7 @@ if __name__ == "__main__":
     parser.add_argument("--longchat_ratio", type=int, default=8, help="Only apply to longchat models. Use ratio=8 for 16K context length model. Only ratio=8 is supported now.")
     parser.add_argument("--eval_shortest_only", action='store_true', default=0, help="Only eval the shortest case for illustration purpose")
     parser.add_argument("--test_dir", type=str, default="evaluation", help="Directory of the testcases")
+    parser.add_argument("--framework", type=str, default=None, help="Framework for serving")
     args = parser.parse_args()
 
     maybe_monkey_patch(args)


### PR DESCRIPTION
This PR introduces support for [vllm](https://github.com/vllm-project/vllm) and [lightllm](https://github.com/vllm-project/vllm) frameworks in the longeval module.

Launch lightllm server:
~~~bash
python -m lightllm.server.api_server --model_dir path/to/weight  --tp 1 --max_total_token_num 12000 --max_req_total_len 20000 --max_req_input_len 15000
~~~

Launch vllm server:
~~~bash
python -m vllm.entrypoints.api_server --model path/to/weight
~~~

Run longeval tests:
~~~bash
# lightllm
python3 eval.py --model-name-or-path path/to/weight  --task topics  --framework lightllm
# vllm
python3 eval.py --model-name-or-path path/to/weight  --task topics  --framework vllm
~~~

These frameworks can help you to evaluate longer prompts within less time